### PR TITLE
Correct type of Route's component prop

### DIFF
--- a/types/Route.d.ts
+++ b/types/Route.d.ts
@@ -2,7 +2,7 @@ import { SvelteComponent, SvelteComponentTyped } from 'svelte';
 
 interface RouteProps {
   path?: string;
-  component?: SvelteComponent;
+  component?: typeof SvelteComponent;
   [additionalProp: string]: unknown;
 }
 


### PR DESCRIPTION
Hi! Love what you've done here!

I added your fork of `svelte-routing` in my `package.json` as a GitHub dependency like so:
```json
"dependencies": {
  "svelte-routing": "henriquehbr/svelte-routing",
}
```

to play around with these types. 

Didn't take long until I stumbled on something not right. 

When passing an imported component to a `Route`'s `component` prop, VSCode gives me this error: 
```
Type 'typeof SomeComponent__SvelteComponent_' is missing the following properties from type 'SvelteComponentDev': $set, $on, $destroy, $$prop_def, and 5 more. ts(2740)
```

So, naturally, I Googled for a bit and came across [this issue](https://github.com/sveltejs/language-tools/issues/486) on [sveltejs/language-tools](https://github.com/sveltejs/language-tools)

As I have my own `ProtectedRoute` component, and could see the error their too; I tried changing the signature of it. And well, sure enough, that removed the error VSCode was complaining about. 

```diff
- export let component: SvelteComponent;
+ export let component: typeof SvelteComponent;
```

So I thought I'd share this with you, and create a PR to hopefully fix it. Can you confirm this isn't just happening to me? 

I don't know how correct or not this is, since I haven't seen anyone else talk about it. Maybe I am missing something, if so please tell me. However, this fixes the error in VSCode for me.

Thanks for your time!

---
EmilTholin/svelte-routing#59